### PR TITLE
Support more uppercase letters in character elements

### DIFF
--- a/src/fountain.js
+++ b/src/fountain.js
@@ -9,7 +9,7 @@
 
     transition: /^((?:FADE (?:TO BLACK|OUT)|CUT TO BLACK)\.|.+ TO\:)|^(?:> *)(.+)/,
     
-    dialogue: /^([A-Z*_]+[0-9A-Z (._\-')]*)(\^?)?(?:\n(?!\n+))([\s\S]+)/,
+    dialogue: /^([\p{Lu}\p{Lt}*_]+[0-9\p{Lu}\p{Lt} (._\-')]*)(\^?)?(?:\n(?!\n+))([\s\S]+)/u,
     parenthetical: /^(\(.+\))$/,
 
     action: /^(.+)/g,


### PR DESCRIPTION
This PR allows more uppercase letters in character elemens and thus adds support for names such as ÉVARISTE or GÜNTER. The [fountain syntax for character elements](https://fountain.io/syntax#section-character) simply asks for uppercase letters so I hope this change is ok. I am far from an expert in regexp and unicode so please feel free to close this PR if there are issues with this solution.